### PR TITLE
Update workflow python version

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.5'
+        python-version: '3.6'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/src/api-engine/tox.ini
+++ b/src/api-engine/tox.ini
@@ -24,4 +24,4 @@ commands = flake8 {toxinidir}
 
 [gh-actions]
 python = 
-    3.5: py35, flake8
+    3.6: py36, flake8


### PR DESCRIPTION
Update workflow python version to 3.6 since latset github ubuntu OS runner doesn't support 3.5 version any more.

Signed-off-by: xichen1 <xichen.pan@gmail.com>